### PR TITLE
replace linkeddata dependency with rdf and nokogiri

### DIFF
--- a/ldpath.gemspec
+++ b/ldpath.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "parslet"
-  spec.add_dependency "linkeddata"
+  spec.add_dependency "rdf", '~> 3.0'
+  spec.add_dependency "nokogiri", "~> 1.8"
 
   # spec.add_development_dependency "bixby", "~> 1.0.0"
   spec.add_development_dependency "bundler", "~> 1.5"

--- a/lib/ldpath.rb
+++ b/lib/ldpath.rb
@@ -1,6 +1,11 @@
 require "ldpath/version"
-require 'linkeddata'
 require 'logger'
+require 'nokogiri'
+require 'rdf'
+# require rdf/ntriples may not be necessary, may only really be necessary
+# for ldpath_program_spec.rb tests, but I'm not certain, and I don't think it hurts
+# to do it here.
+require 'rdf/ntriples'
 
 module Ldpath
   require 'ldpath/field_mapping'


### PR DESCRIPTION
the linkeddata gem (https://github.com/ruby-rdf/linkeddata/) is an omnibus/metadistribution of large parts of the rdf_rb ecosystem, including "all parsing/serialization plugins."  ldpath isn't actually using them all. By replacing dependency with only the sub-parts of `linkeddata` actually being used, we can dramatically reduce the dependency tree of anything downstream from `ldpath`, reducing install time and install size for those downstream things, and eliminating unnecessary dependency tree conflict potential.

`rdf` and `nokogiri` appear to be the only dependencies of `linkeddata` gem that are actually used by ldpath.

Please note: I am not actually familiar with the `ldpath` code or related code, this PR is just based on mechanically trying to get tests to pass with reduced dependencies. If test coverage is poor, this might not be a reliable change? If there are other reasons not captured by tests that removing linkeddata as a dependency could be disruptive for downstream?  I rely on code review from ideally someone more familiar with this ecosystem to give us confidence that this makes sense, maybe @no-reply ?

Closes #19