### PR TITLE
Try to get master green

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,3 @@ language: ruby
 rvm:
   - 2.4.5
   - 2.5.3
-before_install:
-  - gem update --system

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ language: ruby
 rvm:
   - 2.4.5
   - 2.5.3
+before_install:
+  # cause ruby 2.5 doesn't come with bundler 2.x, which our
+  # gemspec now asks for.
+  - gem install bundler

--- a/ldpath.gemspec
+++ b/ldpath.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "linkeddata"
 
   # spec.add_development_dependency "bixby", "~> 1.0.0"
-  spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
* Don't believe gem update is necessary on travis?
  * Plus rubygems 3.1.1 that came out today breaks things with an interactive prompt, can we just avoid it?
* Settle on bundler 2.x
  * Version of bundler allowed is in our gemspec not sure if this is necessary/good practice or not, but if we stick with it, then...
  * We test on ruby 2.5 and 2.6, one comes with bundler 1.x one comes with bundler 2.x, so either one we use, we gotta get the other installed on the relevant system. So let's settle on 2.x, say 2.x in gemspec, ask for latest bundler to be installed on travis instead of relying on what comes with the ruby. 
