### PR TITLE
update CONTRIBUTING doc and README for rename to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,28 @@ https://wiki.duraspace.org/display/samvera/Samvera+Community+Intellectual+Proper
 
 You should also add yourself to the `CONTRIBUTORS.md` file in the root of the project.
 
+## Language
+
+The language we use matters.  Today, tomorrow, and for years to come
+people will read the code we write.  They will judge us for our
+design, logic, and the words we use to describe the system.
+
+Our words should be accessible.  Favor descriptive words that give
+meaning while avoiding reinforcing systemic inequities.  For example,
+in the Samvera community, we should favor using allowed\_list instead
+of whitelist, denied\_list instead of blacklist, or source/copy
+instead of master/slave.
+
+We're going to get it wrong, but this is a call to keep working to
+make it right.  View our code and the words we choose as a chance to
+have a conversation. A chance to grow an understanding of the systems
+we develop as well as the systems in which we live.
+
+See [“Blacklists” and “whitelists”: a salutary warning concerning the
+prevalence of racist language in discussions of predatory
+publishing](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6148600/) for
+further details.
+
 ## Contribution Tasks
 
 * Reporting Issues
@@ -34,7 +56,7 @@ You should also add yourself to the `CONTRIBUTORS.md` file in the root of the pr
 ### Reporting Issues
 
 * Make sure you have a [GitHub account](https://github.com/signup/free)
-* Submit a [Github issue](https://github.com/samvera/questioning_authority/issues) by:
+* Submit a [Github issue](./issues/) by:
   * Clearly describing the issue
     * Provide a descriptive summary
     * Explain the expected behavior
@@ -45,14 +67,21 @@ You should also add yourself to the `CONTRIBUTORS.md` file in the root of the pr
 
 * Fork the repository on GitHub
 * Create a topic branch from where you want to base your work.
-  * This is usually the master branch.
-  * To quickly create a topic branch based on master; `git branch fix/master/my_contribution master`
-  * Then checkout the new branch with `git checkout fix/master/my_contribution`.
-  * Please avoid working directly on the `master` branch.
+  * This is usually the `main` branch.
+  * To quickly create a topic branch based on `main`; `git branch fix/main/my_contribution main`
+  * Then checkout the new branch with `git checkout fix/main/my_contribution`.
+  * Please avoid working directly on the `main` branch.
+  * Please do not create a branch called `master`. (See note below.)
   * You may find the [hub suite of commands](https://github.com/defunkt/hub) helpful
 * Make sure you have added sufficient tests and documentation for your changes.
   * Test functionality with RSpec; Test features / UI with Capybara.
 * Run _all_ the tests to assure nothing else was accidentally broken.
+
+NOTE: This repository follows the [Samvera Community Code of Conduct](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405212316/Code+of+Conduct) 
+and [language recommendations](#language).  
+Please ***do not*** create a branch called `master` for this repository or as part of 
+your pull request; the branch will either need to be removed or renamed before it can 
+be considered for inclusion in the code base and history of this repository.
 
 ### Documenting Code
 
@@ -109,15 +138,15 @@ You should also add yourself to the `CONTRIBUTORS.md` file in the root of the pr
 ### Submitting Changes
 
 * Read the article ["Using Pull Requests"](https://help.github.com/articles/using-pull-requests) on GitHub.
-* Make sure your branch is up to date with its parent branch (i.e. master)
-  * `git checkout master`
+* Make sure your branch is up to date with its parent branch (i.e. main)
+  * `git checkout main`
   * `git pull --rebase`
   * `git checkout <your-branch>`
-  * `git rebase master`
+  * `git rebase main`
   * It is a good idea to run your tests again.
 * If you've made more than one commit take a moment to consider whether squashing commits together would help improve their logical grouping.
   * [Detailed Walkthrough of One Pull Request per Commit](http://ndlib.github.io/practices/one-commit-per-pull-request/)
-  * `git rebase --interactive master` ([See Github help](https://help.github.com/articles/interactive-rebase))
+  * `git rebase --interactive main` ([See Github help](https://help.github.com/articles/interactive-rebase))
   * Squashing your branch's changes into one commit is "good form" and helps the person merging your request to see everything that is going on.
 * Push your changes to a topic branch in your fork of the repository.
 * Submit a pull request from your fork to the project.
@@ -128,11 +157,13 @@ We adopted [Github's Pull Request Review](https://help.github.com/articles/about
 Common checks that may occur in our repositories:
 
 1. Travis CI - where our automated tests are running
-2. Approval Required - Github enforces at least one person approve a pull request. Also, all reviewers that have chimed in must approve.
+2. RuboCop/Bixby - where we check for style violations
+3. Approval Required - Github enforces at least one person approve a pull request. Also, all reviewers that have chimed in must approve.
+4. CodeClimate - is our code remaining healthy (at least according to static code analysis)
 
 If one or more of the required checks failed (or are incomplete), the code should not be merged (and the UI will not allow it). If all of the checks have passed, then anyone on the project (including the pull request submitter) may merge the code.
 
-*Example: Carolyn submits a pull request, Justin reviews the pull request and approves. However, Justin is still waiting on other checks (Travis CI is usually the culprit), so he does not merge the pull request. Eventually, all of the checks pass. At this point, Carolyn or anyone else may merge the pull request.*
+*Example: Carolyn submits a pull request, Justin reviews the pull request and approves. However, Justin is still waiting on other checks (CI tests are usually the culprit), so he does not merge the pull request. Eventually, all of the checks pass. At this point, Carolyn or anyone else may merge the pull request.*
 
 #### Things to Consider When Reviewing
 
@@ -149,7 +180,7 @@ This is your chance for a mentoring moment of another developer. Take time to gi
   * Do new or changed methods, modules, and classes have documentation?
   * Does the commit contain more than it should? Are two separate concerns being addressed in one commit?
   * Does the description of the new/changed specs match your understanding of what the spec is doing?
-  * Did the Travis tests complete successfully?
+  * Did the Continuous Integration tests complete successfully?
 
 If you are uncertain, bring other contributors into the conversation by assigning them as a reviewer.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a ruby implementation of [LDPath](http://marmotta.apache.org/ldpath/language.html), a language for selecting values linked data resources.
 
 [![Gem Version](https://badge.fury.io/rb/ldpath.png)](http://badge.fury.io/rb/ldpath)
-[![Build Status](https://travis-ci.org/samvera-labs/ldpath.png?branch=master)](https://travis-ci.org/samvera-labs/ldpath)
+[![Build Status](https://travis-ci.com/samvera-labs/ldpath.png?branch=master)](https://travis-ci.com/samvera-labs/ldpath)
 [![Coverage Status](https://coveralls.io/repos/github/samvera-labs/ldpath/badge.svg?branch=master)](https://coveralls.io/github/samvera-labs/ldpath?branch=master)
 
 ## Installation
@@ -48,6 +48,12 @@ output = program.evaluate uri, context: context
 ## Compatibility
 
 * Ruby 2.5 or the latest 2.4 version is recommended.  Later versions may also work.
+
+## Contributing 
+
+If you're working on PR for this project, create a feature branch off of `main`. 
+
+This repository follows the [Samvera Community Code of Conduct](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405212316/Code+of+Conduct) and [language recommendations](https://github.com/samvera/maintenance/blob/master/templates/CONTRIBUTING.md#language).  Please ***do not*** create a branch called `master` for this repository or as part of your pull request; the branch will either need to be removed or renamed before it can be considered for inclusion in the code base and history of this repository.
 
 ## Product Owner & Maintenance
 


### PR DESCRIPTION
CONTRIBUTING doc is updated to match current doc available from [samvera/maintenance/CONTRIBUTING.md](https://raw.githubusercontent.com/samvera/maintenance/main/templates/CONTRIBUTING.md)

README updated in accordance with recommendations of Renaming Working Group

Fixes #24
Fixes #25