### PR TITLE
remove pin of rdf and rdf-vocab

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
       - samvera/bundle:
           ruby_version: << parameters.ruby_version >>
           bundler_version: << parameters.bundler_version >>
+          cache_version: "2"
       # - samvera/rubocop
       - samvera/parallel_rspec
 

--- a/ldpath.gemspec
+++ b/ldpath.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "nokogiri", "~> 1.8"
   spec.add_dependency "parslet"
-  spec.add_dependency "rdf", '= 3.1.1' # pinning for LoosePropertySelector
-  spec.add_dependency "rdf-vocab", '= 3.1.1' # pinning for LoosePropertySelector
+  spec.add_dependency "rdf", '~> 3.0'
+  spec.add_dependency 'rdf-vocab', '~> 3.0'
 
   # spec.add_development_dependency "bixby", "~> 1.0.0"
   spec.add_development_dependency "byebug"


### PR DESCRIPTION
Sets the versions for rdf and rdf-vocab to match that used in Hyrax.

NOTE: Had to update the bundler cache in CCI to get tests to pass.  CCI was using an older version of rdf-vocab.
