### PR TITLE
CI Build for Ruby 3.1: Remove coveralls and simplecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,9 @@ workflows:
   ci:
     jobs:
       - bundle_and_test:
+          name: "ruby3-1"
+          ruby_version: "3.1.2"
+      - bundle_and_test:
           name: "ruby3-0"
           ruby_version: "3.0.0"
       - bundle_and_test:

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec path: File.expand_path('..', __FILE__)
-
-group :development, :test do
-  gem 'coveralls', require: false
-  gem 'simplecov', require: false
-end

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ This is a ruby implementation of [LDPath](http://marmotta.apache.org/ldpath/lang
 
 [![Gem Version](https://badge.fury.io/rb/ldpath.png)](http://badge.fury.io/rb/ldpath)
 [![Build Status](https://circleci.com/gh/samvera-labs/ldpath.svg?style=svg)]
-[![Coverage Status](https://coveralls.io/repos/github/samvera-labs/ldpath/badge.svg?branch=master)](https://coveralls.io/github/samvera-labs/ldpath?branch=master)
 
 ## Installation
 

--- a/ldpath.gemspec
+++ b/ldpath.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency "rdf-reasoner"
-  spec.add_development_dependency "simplecov"
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "webmock"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,29 +1,12 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'simplecov'
-SimpleCov.start
-
 require 'ldpath'
 require 'rdf/reasoner'
 require 'webmock/rspec'
-
-require 'simplecov'
-require 'coveralls'
 require 'byebug' unless ENV['TRAVIS']
 
 RDF::Reasoner.apply(:rdfs)
 RDF::Reasoner.apply(:owl)
 
-SimpleCov.formatter = Coveralls::SimpleCov::Formatter
-SimpleCov.start('rails') do
-  add_filter '/.internal_test_app'
-  add_filter '/lib/generators'
-  add_filter '/spec'
-  add_filter '/tasks'
-  add_filter '/lib/qa/version.rb'
-  add_filter '/lib/qa/engine.rb'
-end
-SimpleCov.command_name 'spec'
-Coveralls.wear!
 
 def webmock_fixture(fixture)
   File.new File.expand_path(File.join("../fixtures", fixture), __FILE__)


### PR DESCRIPTION
Removing `coveralls` and `simplecov` (which had not been reporting to coveralls.io for over two years anyway) means the tests now pass in Ruby 3.1.